### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,16 +3,13 @@ from setuptools import setup
 import autopython
 import codecs
 
-with codecs.open('README.rst', encoding='utf-8') as readme_file:
-    long_description = readme_file.read()
-
 setup(
   name = 'autopython',
   version = autopython.__version__,
   license = 'GPLv3',
 
   description = 'Autoscripting for Python 3',
-  long_description = long_description,
+  long_description='Autoscripting Python for your presentations',
 
   packages = ['autopython'],
   scripts = ['bin/autopython'],


### PR DESCRIPTION
To make the setup.py file compliant with Debian and Ubuntu package creation, we should avoid using the Readme as the long description. Using it, makes Lintian fail really hard, and also breaks some guidelines that suggest not to use that long descriptions.

Because of that, I deleted the line that adds the README, and modified the long description with the tentative text "Autoscripting Python for your presentations". Here, if the pull request is accepted, the author should define a proper Long Description for AutoPython.

After this change, and the 8 spaces instead of the tabs proposed earlier, lintian passess all the tests, which is absolutely good for the package to - someday - being accepted in Debian and Ubuntu. The output of lintian is ( after this fixes ) :

juan@beq:~/code/autopython-0.7-b1/deb_dist$ lintian python3-autopython_0.7-1_all.deb 
W: python3-autopython: new-package-should-close-itp-bug
W: python3-autopython: binary-without-manpage usr/bin/autoipython3
W: python3-autopython: binary-without-manpage usr/bin/autopython3

Of course the first should be ignored, while number two and three are related to man pages that are not yet available.
